### PR TITLE
Properly validate shard blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ csmt/badger-test
 
 .idea
 validators.pubs
+vendor/

--- a/beacon/blockchain.go
+++ b/beacon/blockchain.go
@@ -115,7 +115,7 @@ func NewBlockchainWithInitialValidators(db db.Database, config *config.Config, v
 	}
 
 	// this is a new database, so let's populate it with default values
-	node, err := b.View.Index.AddBlockNodeToIndex(&block0, blockHash, stateRoot, proofs.GetValidatorHash(initialState))
+	node, err := b.View.Index.AddBlockNodeToIndex(&block0, blockHash, stateRoot, proofs.GetValidatorHash(initialState, config.EpochLength))
 	if err != nil {
 		return nil, err
 	}

--- a/beacon/rpc/rpc.go
+++ b/beacon/rpc/rpc.go
@@ -402,7 +402,7 @@ func (s *server) GetValidatorRoot(ctx context.Context, req *pb.GetValidatorRootR
 // GetValidatorRoot gets the validator root for a specified block.
 func (s *server) GetValidatorProof(ctx context.Context, req *pb.GetValidatorProofRequest) (*pb.GetValidatorProofResponse, error) {
 	node, state := s.chain.View.GetFinalizedHead()
-	proof, err := proofs.ConstructValidatorProof(&state, req.ValidatorID)
+	proof, err := proofs.ConstructValidatorProof(&state, req.ValidatorID, s.chain.GetConfig().EpochLength)
 	if err != nil {
 		return nil, err
 	}

--- a/beacon/state.go
+++ b/beacon/state.go
@@ -2,8 +2,9 @@ package beacon
 
 import (
 	"errors"
-	"github.com/phoreproject/synapse/primitives/proofs"
 	"time"
+
+	"github.com/phoreproject/synapse/primitives/proofs"
 
 	"github.com/prysmaticlabs/go-ssz"
 
@@ -118,7 +119,7 @@ func (b *Blockchain) ProcessBlock(block *primitives.Block, checkTime bool, verif
 		return nil, nil, err
 	}
 
-	validatorRoot := proofs.GetValidatorHash(newState)
+	validatorRoot := proofs.GetValidatorHash(newState, b.config.EpochLength)
 
 	logger.WithField("new validator root", validatorRoot).Info("applied with new state")
 

--- a/go.mod
+++ b/go.mod
@@ -20,46 +20,39 @@ require (
 	github.com/hsanjuan/go-libp2p-http v0.0.2 // indirect
 	github.com/influxdata/influxdb v1.8.1 // indirect
 	github.com/ipfs/dir-index-html v1.0.3 // indirect
-	github.com/ipfs/go-cid v0.0.3
 	github.com/ipfs/go-ipfs v0.4.22-0.20190911184350-a8fbd066d744 // indirect
 	github.com/ipfs/hang-fds v0.0.1 // indirect
 	github.com/ipfs/iptb-plugins v0.0.2 // indirect
 	github.com/jbenet/go-random-files v0.0.0-20190219210431-31b3f20ebded // indirect
 	github.com/jinzhu/gorm v1.9.10
 	github.com/labstack/echo v3.3.10+incompatible
-	github.com/labstack/gommon v0.3.0
 	github.com/libp2p/go-libp2p v0.3.1
 	github.com/libp2p/go-libp2p-core v0.2.2
-	github.com/libp2p/go-libp2p-crypto v0.1.0
 	github.com/libp2p/go-libp2p-discovery v0.1.0
 	github.com/libp2p/go-libp2p-kad-dht v0.2.1
-	github.com/libp2p/go-libp2p-peer v0.2.0
 	github.com/libp2p/go-libp2p-peerstore v0.1.3
 	github.com/libp2p/go-libp2p-pubsub v0.1.1
-	github.com/minio/sha256-simd v0.1.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mjibson/esc v0.2.0 // indirect
 	github.com/multiformats/go-multiaddr v0.0.4
 	github.com/multiformats/go-multiaddr-net v0.0.1
 	github.com/multiformats/go-multicodec v0.1.6 // indirect
 	github.com/phoreproject/bls v0.0.0-20190821133044-da95d4798b09
-	github.com/phoreproject/go-phore-connmgr v0.2.0
+	github.com/phoreproject/go-phore-connmgr v0.2.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 // indirect
-	github.com/protolambda/zssz v0.1.3
-	github.com/prysmaticlabs/go-bitfield v0.0.0-20190825002834-fb724e897364
+	github.com/protolambda/zssz v0.1.3 // indirect
+	github.com/prysmaticlabs/go-bitfield v0.0.0-20190825002834-fb724e897364 // indirect
 	github.com/prysmaticlabs/go-ssz v0.0.0-20190917152816-977e011d625d
 	github.com/sirupsen/logrus v1.4.2
 	github.com/tevjef/go-runtime-metrics v0.0.0-20170326170900-527a54029307
 	github.com/tyler-smith/go-bip32 v0.0.0-20170922074101-2c9cfd177564 // indirect
 	github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11 // indirect
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
-	golang.org/x/image v0.0.0-20190802002840-cff245a6509b
 	golang.org/x/mod v0.3.0 // indirect
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
 	golang.org/x/sys v0.0.0-20200107162124-548cf772de50
 	golang.org/x/tools v0.0.0-20200619210111-0f592d2728bb // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
 	google.golang.org/grpc v1.27.0
 	google.golang.org/protobuf v1.24.0
 	gopkg.in/yaml.v2 v2.2.4

--- a/go.sum
+++ b/go.sum
@@ -467,6 +467,7 @@ github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgo
 github.com/klauspost/crc32 v0.0.0-20161016154125-cb6bfca970f6/go.mod h1:+ZoRqAPRLkC4NPOvfYeR5KNOrY6TD+/sAC3HXPZgDYg=
 github.com/klauspost/pgzip v1.0.2-0.20170402124221-0bf5dcad4ada/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/koron/go-ssdp v0.0.0-20180514024734-4a0ed625a78b h1:wxtKgYHEncAU00muMD06dzLiahtGM1eouRNOzVV7tdQ=
 github.com/koron/go-ssdp v0.0.0-20180514024734-4a0ed625a78b/go.mod h1:5Ky9EC2xfoUKUor0Hjgi2BJhCSXJfMOFlmyYrVKGQMk=
@@ -649,6 +650,7 @@ github.com/libp2p/go-msgio v0.0.4 h1:agEFehY3zWJFUHK6SEMR7UYmk2z6kC3oeCM7ybLhguA
 github.com/libp2p/go-msgio v0.0.4/go.mod h1:63lBBgOTDKQL6EWazRMCwXsEeEeK9O2Cd+0+6OOuipQ=
 github.com/libp2p/go-nat v0.0.3 h1:l6fKV+p0Xa354EqQOQP+d8CivdLM4kl5GxC1hSc/UeI=
 github.com/libp2p/go-nat v0.0.3/go.mod h1:88nUEt0k0JD45Bk93NIwDqjlhiOwOoV36GchpcVc1yI=
+github.com/libp2p/go-openssl v0.0.2 h1:9pP2d3Ubaxkv7ZisLjx9BFwgOGnQdQYnfcH29HNY3ls=
 github.com/libp2p/go-openssl v0.0.2/go.mod h1:v8Zw2ijCSWBQi8Pq5GAixw6DbFfa9u6VIYDXnvOXkc0=
 github.com/libp2p/go-reuseport v0.0.1 h1:7PhkfH73VXfPJYKQ6JwS5I/eVcoyYi9IMNGc6FWpFLw=
 github.com/libp2p/go-reuseport v0.0.1/go.mod h1:jn6RmB1ufnQwl0Q1f+YxAj8isJgDCQzaaxIFYDhcYEA=
@@ -703,6 +705,7 @@ github.com/mattn/go-sqlite3 v1.10.0 h1:jbhqpg7tQe4SupckyijYiy0mJJ/pRyHvXf7JdWK86
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.11.0 h1:LDdKkqtYlom37fkvqs8rMPFKAMe8+SgjbwZ6ex1/A/Q=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104 h1:d8RFOZ2IiFtFWBcKEHAFYJcPTf0wY5q0exFNJZVWa1U=
 github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -884,6 +887,7 @@ github.com/smola/gocompat v0.2.0/go.mod h1:1B0MlxbmoZNo3h8guHp8HztB3BSYR5itql9qt
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sourcegraph/go-diff v0.5.1/go.mod h1:j2dHj3m8aZgQO8lMTcTnBcXkRRRqi34cd2MNlA9u1mE=
 github.com/spacemonkeygo/openssl v0.0.0-20181017203307-c2dcc5cca94a/go.mod h1:7AyxJNCJ7SBZ1MfVQCWD6Uqo2oubI2Eq2y2eqf+A5r0=
+github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 h1:RC6RW7j+1+HkWaX/Yh71Ee5ZHaHYt7ZP4sQgUrm6cDU=
 github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572/go.mod h1:w0SWMsp6j9O/dk4/ZpIhL+3CkG8ofA2vuv7k+ltqUMc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=

--- a/p2p/hostnode.go
+++ b/p2p/hostnode.go
@@ -31,7 +31,7 @@ const heartbeatInterval = 20 * time.Second
 
 // HostNode is the node for p2p host
 // It's the low level P2P communication layer, the App class handles high level protocols
-// The RPC communication is hanlded by App, not HostNode
+// The RPC communication is handled by App, not HostNode
 type HostNode struct {
 	privateKey crypto.PrivKey
 

--- a/primitives/proofs/validator.go
+++ b/primitives/proofs/validator.go
@@ -10,10 +10,10 @@ import (
 )
 
 // GetValidatorHash gets the merkle root for all currently registered validators.
-func GetValidatorHash(s *primitives.State) chainhash.Hash {
+func GetValidatorHash(s *primitives.State, slotsPerEpoch uint64) chainhash.Hash {
 	committeesPerShard := make(map[uint64]primitives.ShardAndCommittee)
 
-	for _, slotAssignment := range s.ShardAndCommitteeForSlots {
+	for _, slotAssignment := range s.ShardAndCommitteeForSlots[:slotsPerEpoch] {
 		for _, committee := range slotAssignment {
 			committeesPerShard[committee.Shard] = committee
 		}
@@ -51,10 +51,10 @@ func GetValidatorHash(s *primitives.State) chainhash.Hash {
 
 // ConstructValidatorProof constructs a proof that a certain validator was in a
 // certain committee and can be verified using the hash calculated in GetValidatorHash.
-func ConstructValidatorProof(s *primitives.State, forValidator uint32) (*primitives.ValidatorProof, error) {
+func ConstructValidatorProof(s *primitives.State, forValidator uint32, slotsPerEpoch uint64) (*primitives.ValidatorProof, error) {
 	committeesPerShard := make(map[uint64]primitives.ShardAndCommittee)
 
-	for _, slotAssignment := range s.ShardAndCommitteeForSlots {
+	for _, slotAssignment := range s.ShardAndCommitteeForSlots[:slotsPerEpoch] {
 		for _, committee := range slotAssignment {
 			committeesPerShard[committee.Shard] = committee
 		}

--- a/primitives/proofs/validator_test.go
+++ b/primitives/proofs/validator_test.go
@@ -55,9 +55,9 @@ func TestValidatorProof(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootHash := proofs.GetValidatorHash(state)
+	rootHash := proofs.GetValidatorHash(state, c.EpochLength)
 
-	vw, err := proofs.ConstructValidatorProof(state, 10)
+	vw, err := proofs.ConstructValidatorProof(state, 10, c.EpochLength)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/utils/ulimit_freebsd.go
+++ b/utils/ulimit_freebsd.go
@@ -3,7 +3,7 @@
 package utils
 
 import (
-	unix "sys/unix"
+	unix "golang.org/x/sys/unix"
 )
 
 func init() {


### PR DESCRIPTION
This PR adds the following checks to shard blocks:

- [x] Block hash and signature must validate with the included public key in the proof.
- [ ] Proposer index + shard must match algorithm for finding proposer index.
- [ ] Shard block proof must hash to finalized beacon chain block `ValidatorProof` .

Closes #112 